### PR TITLE
Add explicit provider block to module config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,4 +37,8 @@ module "dcos-forwarding-rule-masters" {
   }
 
   labels = "${var.labels}"
+  
+  providers = {
+    google = "google"
+  }
 }


### PR DESCRIPTION
Adding explicit provider block to address errors when passing explicit provider from parent module. 