### PR TITLE
Change modules to use google-beta provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@
  *```
  */
 
-provider "google" {}
+provider "google-beta" {}
 
 module "dcos-forwarding-rule-masters" {
   source  = "dcos-terraform/compute-forwarding-rule/gcp"
@@ -39,6 +39,6 @@ module "dcos-forwarding-rule-masters" {
   labels = "${var.labels}"
   
   providers = {
-    google = "google"
+    google-beta = "google-beta"
   }
 }


### PR DESCRIPTION
In order to not require pinning to an older version of the terraform provider (dcos-terraform/terraform-gcp-dcos#24) the options appear to be 1) remove usage of beta features or 2) move to the google-beta provider. This PR is an attempt at option 2.